### PR TITLE
Support load config from secrets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
         <version>${pulsar.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.streamnative</groupId>
+        <artifactId>pulsar-io-common</artifactId>
+        <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
@@ -170,6 +175,11 @@
     <dependency>
       <groupId>io.streamnative</groupId>
       <artifactId>pulsar-io-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.streamnative</groupId>
+      <artifactId>pulsar-io-common</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/apache/pulsar/ecosystem/io/sqs/SQSSink.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sqs/SQSSink.java
@@ -46,7 +46,7 @@ public class SQSSink extends SQSAbstractConnector implements Sink<GenericRecord>
     @Override
     public void open(Map<String, Object> map, SinkContext sinkContext) throws Exception {
         this.sinkContext = sinkContext;
-        setConfig(SQSConnectorConfig.load(map));
+        setConfig(SQSConnectorConfig.load(map, sinkContext));
         prepareSqsClient();
     }
 

--- a/src/main/java/org/apache/pulsar/ecosystem/io/sqs/SQSSource.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sqs/SQSSource.java
@@ -58,8 +58,7 @@ public class SQSSource extends SQSAbstractConnector implements Source<byte[]> {
     @Override
     public void open(Map<String, Object> map, SourceContext sourceContext) throws Exception {
         this.sourceContext = sourceContext;
-        setConfig(SQSConnectorConfig.load(map));
-        this.getConfig().validate();
+        setConfig(SQSConnectorConfig.load(map, sourceContext));
         prepareSqsClient();
 
         destinationTopic = sourceContext.getOutputTopic();

--- a/src/test/java/org/apache/pulsar/ecosystem/io/sqs/SQSTestUtils.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/sqs/SQSTestUtils.java
@@ -21,9 +21,11 @@ package org.apache.pulsar.ecosystem.io.sqs;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pulsar.io.core.SinkContext;
+import org.apache.pulsar.io.core.SourceContext;
+import org.mockito.Mockito;
 
 /**
  * test utils.
@@ -38,9 +40,14 @@ public class SQSTestUtils {
         return properties;
     }
 
-    public static SQSConnectorConfig getTestConfig() throws IOException {
+    public static SQSConnectorConfig getSourceTestConfig() {
         Map<String, Object> properties = getTestConfigHashMap();
-        return SQSConnectorConfig.load(properties);
+        return SQSConnectorConfig.load(properties, Mockito.mock(SourceContext.class));
+    }
+
+    public static SQSConnectorConfig getSinkTestConfig() {
+        Map<String, Object> properties = getTestConfigHashMap();
+        return SQSConnectorConfig.load(properties, Mockito.mock(SinkContext.class));
     }
 
     public static void purgeSQSQueue(AmazonSQS client, String queueUrl) {

--- a/src/test/java/org/apache/pulsar/ecosystem/io/sqs/integrations/SQSSinkIntegrationTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/sqs/integrations/SQSSinkIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.ecosystem.io.sqs.integrations;
 
-import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.getTestConfig;
+import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.getSinkTestConfig;
 import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.purgeSQSQueue;
 
 import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
@@ -88,7 +88,7 @@ public class SQSSinkIntegrationTest extends AbstractAwsConnector {
     }
 
     public void prepareSQSClient() throws Exception {
-        SQSConnectorConfig config = getTestConfig();
+        SQSConnectorConfig config = getSinkTestConfig();
         config.setQueueName(SQS_QUEUE_NAME);
         AwsCredentialProviderPlugin credentialsProvider = createCredentialProvider(
                 config.getAwsCredentialPluginName(),

--- a/src/test/java/org/apache/pulsar/ecosystem/io/sqs/integrations/SQSSourceIntegrationTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/sqs/integrations/SQSSourceIntegrationTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.ecosystem.io.sqs.integrations;
 
-import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.getTestConfig;
+import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.getSourceTestConfig;
 import static org.apache.pulsar.ecosystem.io.sqs.SQSTestUtils.purgeSQSQueue;
 
 import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
@@ -116,7 +116,7 @@ public class SQSSourceIntegrationTest extends AbstractAwsConnector {
     }
 
     public void prepareSQSClient() throws Exception {
-        SQSConnectorConfig config = getTestConfig();
+        SQSConnectorConfig config = getSourceTestConfig();
         config.setQueueName(SQS_QUEUE_NAME);
         AwsCredentialProviderPlugin credentialsProvider = createCredentialProvider(
                 config.getAwsCredentialPluginName(),


### PR DESCRIPTION
### Motivation
#11 Support load config from secrets

### Modifications
- Set `sensitive=true` on awsCredentialPluginParam filed.
- Add `load(Map, SinkContext)` and `load(Map, SourceContext)` method on SQSConnectorConfig
- Fix some unit tests.

### Verifying this change
- Add the `testLoadConfigFromSecret` unit test to cover it.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

